### PR TITLE
Added logger to fix debug error. Fixed secret name for api encryption key. Fix indenting for local es8311

### DIFF
--- a/waveshare-s3-audio.yaml
+++ b/waveshare-s3-audio.yaml
@@ -132,6 +132,9 @@ wifi:
 debug:
   update_interval: 5s
 
+logger:
+  level: DEBUG
+
 api:
   id: api_id
   actions:
@@ -177,7 +180,7 @@ api:
     - script.execute: control_leds
 
   encryption:
-    key: !secret "api_${esp32-audio-3}"
+    key: !secret api_esp32-audio-s3
 
 # http_request: 
 #   verify_ssl: false
@@ -276,11 +279,11 @@ audio_adc:
     bits_per_sample: $i2s_bps_mic
     #bits_per_sample: "${i2s_bits_per_sample}bit"
 
-#external_components:
-#  - source:
-#    type: local
-#    path: components
-#    components: [ es8311 ]
+# external_components:
+#   - source:
+#       type: local
+#       path: components
+#     components: [ es8311 ]
 external_components:
   - source:
       type: git


### PR DESCRIPTION
I didn't have any luck with the way the encryption key was setup (I don't think substitution works with secret names? It also seemed to be misnamed as "esp32-audio-s3" instead of "device_name"), and I also added the logger component to fix a complaint about the debug component not having the logger component.

Also fixed indentation for the local external component.