### PR TITLE
Camera Platform Updates

### DIFF
--- a/waveshare_camera_pkg.yaml
+++ b/waveshare_camera_pkg.yaml
@@ -11,14 +11,20 @@ substitutions:
   camera_href_pin: GPIO1
   camera_pclk_pin: GPIO44
   camera_xclk_pin: GPIO43  #External clock
-  camera_power_pin: 
+  camera_select_pin:
       tca9555: ioexp
       number: 6 #EXIO6 
+  camera_power_pin:
+      tca9555: ioexp
+      number: 5 #EXIO5
       inverted: true
   camera_max_framerate: '15fps'
+  camera_jpeg_quality_index: '0'
   camera_jpeg_quality: '10'
+  camera_resolution_index: '0'
   camera_vertical_flip: 'true'
   camera_horizontal_mirror: 'true'
+  camera_rotate_180: 'true'
   camera_contrast: '0'
   camera_brightness: '0'
   camera_saturation: '0'
@@ -26,6 +32,7 @@ substitutions:
   camera_aec_mode: 'auto'
   camera_aec2: 'false'
   camera_ae_level: '0'
+  camera_ae_enable: 'true'
   camera_aec_value: '300'
   camera_agc_mode: 'auto'
   camera_agc_value: '0'
@@ -34,48 +41,7 @@ substitutions:
 
   #TODO: make HA switches
   camera_xclk_frequency: 12MHz
-  camera_idle_framerate: 0fps
-
-esphome:
-  on_boot:
-    - priority: -100
-      then:
-        - if:
-            condition:
-              lambda: 'return id(image_rotated);'
-            then:
-              - lambda: |-
-                  sensor_t *s = esp_camera_sensor_get();
-                  if (s != nullptr) {
-                    s->set_vflip(s, 1);
-                    s->set_hmirror(s, 1);
-                  }
-              - switch.turn_on: camera_rotation_switch
-        - if:
-            condition:
-              lambda: 'return id(auto_exposure_enabled);'
-            then:
-              - lambda: |-
-                  sensor_t *s = esp_camera_sensor_get();
-                  if (s != nullptr) { s->set_exposure_ctrl(s, 1); }
-              - switch.turn_on: camera_aec_switch
-            else:
-              - lambda: |-
-                  sensor_t *s = esp_camera_sensor_get();
-                  if (s != nullptr) { s->set_exposure_ctrl(s, 0); }
-              - switch.turn_off: camera_aec_switch
-
-globals:
-  # TODO: fuse substitution set settings to boot settings
-  - id: image_rotated
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-
-  - id: auto_exposure_enabled
-    type: bool
-    restore_value: yes
-    initial_value: 'true' # Default to ON
+  camera_idle_framerate: 0.1fps
 
 # Camera configuration
 esp32_camera:
@@ -89,7 +55,7 @@ esp32_camera:
     pin: $camera_xclk_pin
     frequency: $camera_xclk_frequency #12MHz
   i2c_id: $i2c_id
-  #power_down_pin: ${camera_power_pin}
+#  power_down_pin: ${camera_power_pin}
 
   #frame settings  
   max_framerate: ${camera_max_framerate}
@@ -97,6 +63,8 @@ esp32_camera:
   
   #Image Settings
   resolution: 1280X1024
+  frame_buffer_location: PSRAM
+  frame_buffer_count: 2
   jpeg_quality: ${camera_jpeg_quality}
   vertical_flip: ${camera_vertical_flip}
   horizontal_mirror: ${camera_horizontal_mirror}
@@ -119,217 +87,351 @@ esp32_camera:
   #White balance settings
   wb_mode: ${camera_white_balance}
 
-sensor: 
-  - platform: homeassistant
-    id: camera_jpeg_quality
-    entity_id: input_number.camera_jpeg_quality
+globals:
+  - id: defer_camera_update
+    type: bool
+    restore_value: False
+    initial_value: 'false'
+  - id: camera_power_save
+    type: bool
+    restore_value: True
+    initial_value: 'true'
+  - id: camera_select_save
+    type: bool
+    restore_value: True
+    initial_value: 'true'
 
-  - platform: homeassistant
-    id: camera_vertical_flip
-    entity_id: input_boolean.camera_vertical_flip
-
-  - platform: homeassistant
-    id: camera_horizontal_mirror
-    entity_id: input_boolean.camera_horizontal_mirror
-
-  - platform: homeassistant
-    id: camera_brightness
-    entity_id: input_number.camera_brightness
-
-  - platform: homeassistant
-    id: camera_contrast
-    entity_id: input_number.camera_contrast
-
-  - platform: homeassistant
-    id: camera_saturation
-    entity_id: input_number.camera_saturation
-
-  - platform: homeassistant
-    id: camera_special_effect
-    entity_id: input_select.camera_special_effect
-
-  - platform: homeassistant
-    id: camera_aec_mode
-    entity_id: input_select.camera_aec_mode
-
-  - platform: homeassistant
-    id: camera_aec2
-    entity_id: input_boolean.camera_aec2
-
-  - platform: homeassistant
-    id: camera_ae_level
-    entity_id: input_number.camera_ae_level
-
-  - platform: homeassistant
-    id: camera_ae_value
-    entity_id: input_number.camera_ae_value 
-   
-  - platform: homeassistant
-    id: camera_agc_mode
-    entity_id: input_select.camera_agc_mode
-
-  - platform: homeassistant
-    id: camera_agc_ceiling
-    entity_id: input_number.camera_agc_ceiling
-
-  - platform: homeassistant
-    id: camera_agc_value
-    entity_id: input_number.camera_agc_value
-
-  - platform: homeassistant
-    id: camera_white_balance
-    entity_id: input_select.camera_white_balance
+esphome:
+  on_boot:
+    - priority: -100
+      then:
+          # If the user disables power and de-selects the camera, when the
+          # device restarts the camera would fail to initialize which can't
+          # be corrected without another restart.  To get around this,
+          # both power and select are always enabled at boot then after everything
+          # is initialized, they're disabled if needed.  This allows the user to
+          # turn them back on again without needing to restart.
+        - switch.control:
+            id: camera_power_switch
+            state: !lambda return id(camera_power_save);
+        - switch.control:
+            id: camera_select_switch
+            state: !lambda return id(camera_select_save);
 
 select:
+    # Camera resolution can't be changed on the fly because the underlying
+    # camera code sets up the frame buffer only once during setup and that's
+    # dependent on frame size.
   - platform: template
-    name: "Camera Resolution"
+    name: "Camera Resolution (restart required)"
     id: camera_resolution_select
     icon: "mdi:aspect-ratio"
+    optimistic: true
+    restore_value: true
+    disabled_by_default: true
     options: ["QVGA (320x240)", "VGA (640x480)", "SVGA (800x600)", "XGA (1024x768)", "UXGA (1600x1200)"]
-    set_action:
-      - lambda: |-
-          sensor_t *s = esp_camera_sensor_get();
-          if (s == nullptr) { return; }
-          framesize_t new_framesize = FRAMESIZE_INVALID;
-          if (x == "QVGA (320x240)") new_framesize = FRAMESIZE_QVGA;
-          else if (x == "VGA (640x480)") new_framesize = FRAMESIZE_VGA;
-          else if (x == "SVGA (800x600)") new_framesize = FRAMESIZE_SVGA;
-          else if (x == "XGA (1024x768)") new_framesize = FRAMESIZE_XGA;
-          else if (x == "UXGA (1600x1200)") new_framesize = FRAMESIZE_UXGA;
-          if (new_framesize != FRAMESIZE_INVALID && s->set_framesize(s, new_framesize) == 0) {
-            id(camera_resolution_select).publish_state(x);
-            id(current_resolution).publish_state(x);
-          }
+    on_value:
+      then:
+        - lambda: |-
+            // This code does nothing unless run before setup has run.
+            // 'i' is set to the index of the currently selected option.
+            esp32_camera::ESP32CameraFrameSize fs[] = {
+              esp32_camera::ESP32_CAMERA_SIZE_320X240,
+              esp32_camera::ESP32_CAMERA_SIZE_640X480,
+              esp32_camera::ESP32_CAMERA_SIZE_800X600,
+              esp32_camera::ESP32_CAMERA_SIZE_1024X768,
+              esp32_camera::ESP32_CAMERA_SIZE_1600X1200
+            };
+            id(seeed_camera).set_frame_size(fs[i]);
 
+    # Unlike resolution, quality can be set on the fly.
   - platform: template
-    name: "JPEG Quality"
+    name: "Camera Quality"
     id: camera_jpeg_quality_select
     icon: "mdi:image-size-select-large"
+    optimistic: true
+    restore_value: true
+    disabled_by_default: true
     options: ["Best (10)", "Good (15)", "Medium (25)", "Low (40)", "Fastest (63)"]
-    set_action:
-      - lambda: |-
-          sensor_t *s = esp_camera_sensor_get();
-          if (s == nullptr) { return; }
-          size_t first = x.find("(");
-          size_t last = x.find(")");
-          int quality = std::stoi(x.substr(first + 1, last - first - 1));
-          if (s->set_quality(s, quality) == 0) {
-            id(camera_jpeg_quality_select).publish_state(x);
-            id(current_jpeg_quality).publish_state(x);
-          }
+    on_value:
+      then:
+        - lambda: |-
+            // 'i' is set to the index of the currently selected option.
+            int qa[] = { 10, 15, 25, 40, 63 };
+            id(seeed_camera).set_jpeg_quality(qa[i]);
+            // esp32_camera doesn't include jpeg quality in update_camera_parameters. :(
+            sensor_t *s = esp_camera_sensor_get();
+            if (s != nullptr) {
+              s->set_quality(s, qa[i]);
+            }
 
-text_sensor:
   - platform: template
-    name: "Current Camera Resolution"
-    id: current_resolution
-    icon: "mdi:camera-control"
-  - platform: template
-    name: "Current JPEG Quality"
-    id: current_jpeg_quality
-    icon: "mdi:quality-high"
+    name: "Camera AGC Ceiling"
+    id: camera_agc_gain_select
+    icon: "mdi:image-size-select-large"
+    optimistic: true
+    restore_value: true
+    disabled_by_default: true
+    options: ["2x", "4x", "8x", "16x", "32x", "64x", "128x" ]
+    on_value:
+      then:
+        - lambda: |-
+            // 'i' is set to the index of the currently selected option.
+            esp32_camera::ESP32AgcGainCeiling agc[] = {
+              esp32_camera::ESP32_GAINCEILING_2X,
+              esp32_camera::ESP32_GAINCEILING_4X,
+              esp32_camera::ESP32_GAINCEILING_8X,
+              esp32_camera::ESP32_GAINCEILING_16X,
+              esp32_camera::ESP32_GAINCEILING_32X,
+              esp32_camera::ESP32_GAINCEILING_64X,
+              esp32_camera::ESP32_GAINCEILING_128X,
+            };
+            id(seeed_camera).set_agc_gain_ceiling(agc[i]);
+            if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
 
 switch:
+    # We need to maintain our own restore state for both select and power
+    # because they both have to be ON before the camera is initialized
+    # then turned off afterwards if the user has turned them off explicitly.
+    # This is also why we need a separate template and gpio switch for each.
   - platform: template
-    name: "Camera Control"
-    id: camera_control_template
+    name: "Camera Select"
+    id: camera_select_switch
     optimistic: True
-    turn_on_action: 
-      then:
-        - switch.turn_on: camera_power_output
-    turn_off_action: 
-      then:
-        - switch.turn_off: camera_power_output    
-  
-  - platform: restart
-    id: seecd_restart
-    name: "Camera Restart" 
+    disabled_by_default: true
+    restore_mode: DISABLED
+    on_state:
+      - lambda: |-
+          id(camera_select_gpio).control(x);
+          id(camera_select_save) = x;
+
+  - platform: gpio
+    pin: ${camera_select_pin}
+    id: camera_select_gpio
+    restore_mode: ALWAYS_ON
+    internal: True
+
+  - platform: template
+    name: "Camera Power"
+    id: camera_power_switch
+    optimistic: True
+    disabled_by_default: true
+    restore_mode: DISABLED
+    on_state:
+      - lambda: |-
+          id(camera_power_gpio).control(x);
+          id(camera_power_save) = x;
   
   - platform: gpio
     pin: ${camera_power_pin}
-    id: camera_power_output
-    name: "camera output"
+    id: camera_power_gpio
+    restore_mode: ALWAYS_ON
+    internal: True
 
   - platform: template
-    name: "Reset Camera"
-    id: reset_camera_settings
-    turn_on_action: # Reset values to default
-      - lambda: |-
-          // Set camera to default values using substitutions and proper conversions
-          id(seeed_camera).set_contrast(0);
-          id(seeed_camera).set_brightness(0);     
-      - switch.turn_off: reset_camera_settings  # Ensure the switch is momentary
-      
-  - platform: template
-    name: "Rotate Image 180°"
+    name: "Camera Rotate 180°"
     id: camera_rotation_switch
     icon: "mdi:rotate-3d-variant"
-    lambda: 'return id(image_rotated);'
-    turn_on_action:
+    disabled_by_default: true
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: True
+    on_state:
       - lambda: |-
-          sensor_t *s = esp_camera_sensor_get();
-          if (s != nullptr) {
-            s->set_vflip(s, 1);
-            s->set_hmirror(s, 1);
-            id(image_rotated) = true;
-          }
-    turn_off_action:
-      - lambda: |-
-          sensor_t *s = esp_camera_sensor_get();
-          if (s != nullptr) {
-            s->set_vflip(s, 0);
-            s->set_hmirror(s, 0);
-            id(image_rotated) = false;
-          }
+          id(seeed_camera).set_horizontal_mirror(x);
+          id(seeed_camera).set_vertical_flip(x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
 
   - platform: template
-    name: "Auto Exposure Control"
+    name: "Camera AEC"
     id: camera_aec_switch
-    icon: "mdi:auto-fix-high"
-    lambda: 'return id(auto_exposure_enabled);'
-    turn_on_action:
+    icon: "mdi:brightness-7"
+    restore_mode: RESTORE_DEFAULT_ON
+    disabled_by_default: true
+    optimistic: True
+    on_state:
       - lambda: |-
-          sensor_t *s = esp_camera_sensor_get();
-          if (s != nullptr) {
-            s->set_exposure_ctrl(s, 1);
-            id(auto_exposure_enabled) = true;
-          }
-    turn_off_action:
+          id(seeed_camera).set_aec_mode(x ? esp32_camera::ESP32_GC_MODE_AUTO : esp32_camera::ESP32_GC_MODE_MANU);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+
+  - platform: template
+    name: "Camera AEC2"
+    id: camera_aec2_switch
+    icon: "mdi:brightness-7"
+    restore_mode: RESTORE_DEFAULT_OFF
+    disabled_by_default: true
+    optimistic: True
+    on_state:
       - lambda: |-
-          sensor_t *s = esp_camera_sensor_get();
-          if (s != nullptr) {
-            s->set_exposure_ctrl(s, 0);
-            id(auto_exposure_enabled) = false;
-          }
+          id(seeed_camera).set_aec2(x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+
+  - platform: template
+    name: "Camera AGC"
+    id: camera_agc_switch
+    icon: "mdi:brightness-7"
+    restore_mode: RESTORE_DEFAULT_ON
+    disabled_by_default: true
+    optimistic: True
+    on_state:
+      - lambda: |-
+          id(seeed_camera).set_agc_mode(x ? esp32_camera::ESP32_GC_MODE_AUTO : esp32_camera::ESP32_GC_MODE_MANU);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+
+  - platform: template
+    name: "Camera Test Pattern"
+    id: camera_test_pattern_switch
+    icon: "mdi:brightness-7"
+    restore_mode: RESTORE_DEFAULT_OFF
+    disabled_by_default: true
+    optimistic: True
+    on_state:
+      - lambda: |-
+          id(seeed_camera).set_test_pattern(x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
 
 number:
   - platform: template
-    name: "AE Level"
+    name: "Camera AEC +-"
     id: camera_ae_level_number
-    icon: "mdi:exposure"
+    icon: "mdi:brightness-7"
     optimistic: true
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 0
     min_value: -2
     max_value: 2
     step: 1
     mode: slider
     set_action:
       - lambda: |-
-          sensor_t *s = esp_camera_sensor_get();
-          if (s != nullptr) {
-            s->set_ae_level(s, (int)x);
-          }
+          id(seeed_camera).set_ae_level((int)x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
 
   - platform: template
-    name: "Manual Exposure Time"
-    id: camera_aec_value_number
-    icon: "mdi:camera-timer"
+    name: "Camera AGC +-"
+    id: camera_agc_value_number
+    icon: "mdi:brightness-7"
     optimistic: true
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 0
+    min_value: 0
+    max_value: 30
+    step: 1
+    mode: slider
+    set_action:
+      - lambda: |-
+          id(seeed_camera).set_agc_value((int)x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+
+  - platform: template
+    name: "Camera Brightness"
+    id: camera_brightness_number
+    icon: "mdi:brightness-7"
+    optimistic: true
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 0
+    min_value: -2
+    max_value: 2
+    step: 1
+    mode: slider
+    set_action:
+      - lambda: |-
+          id(seeed_camera).set_brightness((int)x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+
+  - platform: template
+    name: "Camera Contrast"
+    id: camera_contrast_number
+    icon: "mdi:brightness-7"
+    optimistic: true
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 0
+    min_value: -2
+    max_value: 2
+    step: 1
+    mode: slider
+    set_action:
+      - lambda: |-
+          id(seeed_camera).set_contrast((int)x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+
+  - platform: template
+    name: "Camera Saturation"
+    id: camera_saturation_number
+    icon: "mdi:brightness-7"
+    optimistic: true
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 0
+    min_value: -2
+    max_value: 2
+    step: 1
+    mode: slider
+    set_action:
+      - lambda: |-
+          id(seeed_camera).set_saturation((int)x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+
+  - platform: template
+    name: "Camera ISO"
+    id: camera_aec_value_number
+    icon: "mdi:brightness-7"
+    optimistic: true
+    disabled_by_default: true
+    restore_value: true
+    initial_value: 300
     min_value: 0
     max_value: 1200
     step: 1
     mode: slider
     set_action:
       - lambda: |-
-          sensor_t *s = esp_camera_sensor_get();
-          if (s != nullptr) {
-            s->set_aec_value(s, (int)x);
-          }
+          id(seeed_camera).set_aec_value((int)x);
+          if (!id(defer_camera_update) && esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+
+button:
+  - platform: template
+    name: "Camera Settings Reset"
+    id: reset_camera_settings
+    device_class: restart
+    disabled_by_default: true
+    on_press:
+      - lambda: id(defer_camera_update) = true;
+      - select.set_index:
+          id: camera_resolution_select
+          index: 0
+      - select.set_index:
+          id: camera_jpeg_quality_select
+          index: 2
+      - select.set_index:
+          id: camera_agc_gain_select
+          index: 0
+      - switch.turn_off: camera_rotation_switch
+      - switch.turn_on: camera_aec_switch
+      - switch.turn_on: camera_agc_switch
+      - switch.turn_off: camera_test_pattern_switch
+      - number.set:
+          id: camera_ae_level_number
+          value: 0
+      - number.set:
+          id: camera_aec_value_number
+          value: 300
+      - number.set:
+          id: camera_agc_value_number
+          value: 0
+      - number.set:
+          id: camera_brightness_number
+          value: 0
+      - number.set:
+          id: camera_contrast_number
+          value: 0
+      - number.set:
+          id: camera_saturation_number
+          value: 0
+      - lambda: |-
+          if (esp_camera_sensor_get() != nullptr) id(seeed_camera).update_camera_parameters();
+          id(defer_camera_update) = false;
+


### PR DESCRIPTION
* All controls now properly save and restore on device restarts.

* Where supported by the underlying camera code, control changes are live.

* The "Camera Resolution" control now indicates "restart required" to indicate
  that a restart is required for the change to take effect.  This is because
  the frame buffer size is calculated based on the frame size set at startup
  and the API that changes the resolution doesn't recalculate it. The result
  is that changing the frame size live results in buffer errors.  To prevent
  that, changes are saved to the device NVRAM only and read back at startup
  before the camera initializes.  The "Current Camera Resolution" text
  sensor has been removed since the resolution control now updates
  correctly.

* The "JPEG Quality" control is renamed to "Camera Quality" to keep it grouped
  with other camera controls. The "Current JPEG Quality" text sensor has been
  removed since the quality control now updates correctly.

* The "Auto Exposure" and "Auto Exposure Level" controls have been renamed to
  "Camera AEC" and "Camera AEC+-" to keep them grouped with the other camera
  controls.

* The "Manual Exposure Time" control has been renamed to "Camera ISO" to
  better reflect what it does and keep it grouped with the other camera
  controls.

* The "Rotate Image 180°" control has bene renamed to "Camera Rotate 180°"
  to keep it grouped with the other camera controls.

* The "Camera Control" control has been renamed to "Camera Select" since it
  toggles the camera select pin on the camera.  The "camera output" control
  has been hidden as it's an internal switch.

* A "Camera Power" control has been added that actually turns the camera
  power on and off.  NOTE:  This Waveshare device does not have the ability
  to toggle the power automatically based on whether the camera is streaming
  or not.  Although the esp32_camera component does have that capability,
  it's restricted to native GPIO pins but the device uses a pin on a
  GPIO expander to control the power.

* Added the following controls:
  Camera AEC2
  Camera AGC
  Camera AGC +-
  Camera AGC Gain Ceiling
  Camera Brightness
  Camera Contrast
  Camera Saturation
  Camera Test Pattern
