### PR TITLE
Fix issues in waveshare-s3-audio.yaml.

### DIFF
--- a/waveshare-s3-audio.yaml
+++ b/waveshare-s3-audio.yaml
@@ -117,8 +117,6 @@ esp32:
 wifi:
   id: wifi_id
   fast_connect: ${hidden_ssid}
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
   power_save_mode: none  # Disable power saving for better performance
   reboot_timeout: 10min  # Prevent unnecessary reboots
   on_connect:
@@ -180,16 +178,12 @@ api:
   on_client_disconnected:
     - script.execute: control_leds
 
-  encryption:
-    key: !secret api_esp32-audio-s3
-
 # http_request: 
 #   verify_ssl: false
 
 ota:
   - platform: esphome
     id: ota_esphome
-    password: !secret ota_password
 
 i2c:
   - id: internal_i2c
@@ -1119,7 +1113,7 @@ switch:
 
   - platform: template
     id: mute_sound
-    name: Mute/unmute sound
+    name: Mute-unmute sound
     icon: "mdi:bullhorn"
     entity_category: config
     optimistic: true
@@ -1190,8 +1184,7 @@ number:
       - logger.log:
           format: "[MIC] Set ES7210 gain to %.0f dB"
           args: ["x"]
-          
-    - platform: template
+  - platform: template
     id: va_gain_factor
     name: "Gain Factor"
     entity_category: config
@@ -1287,6 +1280,7 @@ button:
 
 binary_sensor:
   - platform: gpio
+    id: key1_button
     name: "Key1"
     pin:
       tca9555: ioexp
@@ -1296,6 +1290,7 @@ binary_sensor:
       - media_player.volume_down: external_media_player
 
   - platform: gpio
+    id: key2_button
     name: "Key2"
     pin:
       tca9555: ioexp
@@ -1305,6 +1300,7 @@ binary_sensor:
       - media_player.toggle: external_media_player
 
   - platform: gpio
+    id: key3_button
     name: "Key3"
     pin:
       tca9555: ioexp


### PR DESCRIPTION
* Removed secrets from wifi, api and ota nodes.
  Per https://esphome.io/components/packages/ packages can't have secrets
  and they can't bve overridden in a device-specific yaml.

* Fix bad indent that causes the file to fail to load.

* Change "Mute/unmute sound" to "Mute-unmute sound" as ESPHome warns that
  the slash is considered a path separator and will cause a failure
  in future releases.

* Add ids to the key binary sensors to make it easier to extend them.

Resolves: #10
Resolves: #5
